### PR TITLE
Use alpine image to reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ottomated/crewlink-server
-FROM node:14-alpine
+FROM node:lts-alpine
 
 # Make a directory for the app, give node user permissions
 RUN mkdir /app && chown node:node /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ottomated/crewlink-server
-FROM node:14
+FROM node:14-alpine
 
 # Make a directory for the app, give node user permissions
 RUN mkdir /app && chown node:node /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,12 @@ FROM node:lts-alpine
 
 # Change to the /app directory *and* make it the default execution directory
 WORKDIR /app
-                                                                            # Copy relevant files from previous stage
-COPY --chown=node:node --from=builder /app/dist ./dist                      COPY --chown=node:node --from=builder /app/node_modules ./node_modules
-                                                                            # Start the image as node
+
+# Copy relevant files from previous stage
+COPY --chown=node:node --from=builder /app/dist ./dist
+COPY --chown=node:node --from=builder /app/node_modules ./node_modules
+     
+# Start the image as node
 USER node
 
 # Tell the Docker engine the default port is 9736


### PR DESCRIPTION
I haven't tested further, but at the very least the alpine version starts up after docker build on my raspberry pi (armhf) 