### PR TITLE
Adds "Deploy to Heroku" button

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node dist/index.js

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: yarn start
+web: node dist/index.js

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node dist/index.js
+web: yarn start

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GPL-3.0 License][license-shield]][license-url] [![Docker Pulls][docker-shield]][docker-url] [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![GPL-3.0 License][license-shield]][license-url] [![Docker Pulls][docker-shield]][docker-url] 
 
 <br />
 <p align="center">
@@ -37,6 +37,14 @@
 ## About The Project
 
 This is the relay server for CrewLink, an Among Us proximity voice chat program. I am currently hosting a server at `ottomated.net:9736`, but if you want a more reliable option I would suggest to deploy this repository yourself.
+
+## Deploy to Heroku
+
+To get up and running quickly, you can deploy to Heroku using the button below
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+This will deploy an instance of the crewlink-server. You can get the URL of your server by using the app name that you gave when you launched the app on heroku and appending `.herokuapp.com`. You can also find the URL of your server by going to "Settings", scrolling down to "Domains", and removing the `https://` and trailing slash from the url. Using this URL, follow step 4 of the [installation instructions](https://github.com/ottomated/CrewLink-server#manual-installation) to connect your client to your server instance.
 
 ## Docker Quickstart
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GPL-3.0 License][license-shield]][license-url] [![Docker Pulls][docker-shield]][docker-url]
+[![GPL-3.0 License][license-shield]][license-url] [![Docker Pulls][docker-shield]][docker-url] [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 <br />
 <p align="center">

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "CrewLink Server",
+  "description": "Voice Relay server for CrewLink",
+  "repository": "https://github.com/ottomated/CrewLink-server",
+  "logo": "https://github.com/ottomated/CrewLink-server/raw/master/logo.png",
+  "keywords": ["node", "among us"]
+}

--- a/app.json
+++ b/app.json
@@ -3,8 +3,5 @@
   "description": "Voice Relay server for CrewLink",
   "repository": "https://github.com/ottomated/CrewLink-server",
   "logo": "https://github.com/ottomated/CrewLink-server/raw/master/logo.png",
-  "keywords": ["node", "among us"],
-  "engines": {
-    "node": "14.x"
-  }
+  "keywords": ["node", "among us"]
 }

--- a/app.json
+++ b/app.json
@@ -3,5 +3,8 @@
   "description": "Voice Relay server for CrewLink",
   "repository": "https://github.com/ottomated/CrewLink-server",
   "logo": "https://github.com/ottomated/CrewLink-server/raw/master/logo.png",
-  "keywords": ["node", "among us"]
+  "keywords": ["node", "among us"],
+  "engines": {
+    "node": "14.x"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
  },
  "scripts": {
   "start": "yarn compile && node dist/index.js",
-  "compile": "tsc"
+  "compile": "tsc",
+  "postinstall": "yarn compile"
  },
  "devDependencies": {
   "@types/express": "^4.17.8",


### PR DESCRIPTION
Heroku has a pretty generous free tier, and getting up and running on heroku is fairly friendly to those less familiar with running their own servers. In this PR I've added the "Deploy to Heroku" button as well as some instructions to get up and running. Hopefully this can make getting up and running with crewlink-server a bit easier. 

You can test this PR by deploying an instance of the server from my fork of the repo. I got one up and running and verified that it worked by starting an among us lobby with a friend to confirm that we had voice connection and falloff.