### PR TITLE
Add meta tags to show info in third party embeds

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -21,6 +21,10 @@ head
 		a:hover {
 			text-decoration: underline;
 		}
+	meta(property='og:title', content='CrewLink Server')
+	meta(property='og:description', content='Among Us proximity voice chat')
+	meta(property='twitter:label1', content='Users')
+	meta(property='twitter:data1', content=connectionCount)
 img(src="https://github.com/ottomated/CrewLink/raw/master/logo.png")
 h1 CrewLink Server
 p This is a CrewLink Server running on #{address}.


### PR DESCRIPTION
Add meta tags to the index page to show unfurled information when people link it in third party apps that support it, such as Discord or Slack
![image](https://user-images.githubusercontent.com/1478389/101237556-14b06c00-3697-11eb-946f-b499574e0f46.png)
