### PR TITLE
Fix for named pipes support as port. 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import Tracer from 'tracer';
 import morgan from 'morgan';
 import publicIp from 'public-ip';
 
-const port = parseInt(process.env.PORT || '9736');
+const port = process.env.PORT || '9736';
 
 const logger = Tracer.colorConsole({
 	format: "{{timestamp}} <{{title}}> {{message}}"


### PR DESCRIPTION
Removed the parseint function from to get the port for named pipes support.
This is needed if u want to host it under an IIS webserver using iisnode. 
