### PR TITLE
Fix memory leak with playerIds and disconnecting users

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,7 @@ io.on('connection', (socket: socketIO.Socket) => {
 
 	socket.on('disconnect', () => {
 		connectionCount--;
+		playerIds.delete(socket.id);
 		logger.info("Total connected: %d", connectionCount);
 	})
 


### PR DESCRIPTION
Simple issue, while playerIds is used in the id event, it's never actually removed. As more users connect and disconnect, server memory will just keep going up, storing useless socket ids and player ids.