### PR TITLE
Added option to hide ip on the web interface, and in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Optional environment variables:
  - `NAME`: Specifies the server name
  - `HTTPS`: Enables https. You must place `privkey.pem` and `fullchain.pem` in your CWD.
  - `SSLPATH`: Specifies an alternate path to SSL certificates.
+ - `HIDEIP`: If set, hides the public ip on the public website, replacing it with redacted.
 
 ## Deploy to Heroku
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
-import express from 'express';
-import { Server } from 'http';
-import { Server as HttpsServer } from 'https';
 import { readFileSync, readdirSync } from 'fs';
-import { join } from 'path';
-import socketIO from 'socket.io';
+
+import { Server as HttpsServer } from 'https';
+import { Server } from 'http';
 import Tracer from 'tracer';
+import express from 'express';
+import { join } from 'path';
 import morgan from 'morgan';
 import publicIp from 'public-ip';
+import socketIO from 'socket.io';
 
 const httpsEnabled = !!process.env.HTTPS;
 
@@ -45,7 +46,7 @@ let connectionCount = 0;
 let address = process.env.ADDRESS;
 
 app.get('/', (_, res) => {
-	res.render('index', { connectionCount, address });
+	res.render('index', { connectionCount, address: process.env.HIDEIP ? `<redacted>:${port}` : address });
 });
 
 app.get('/health', (req, res) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ app.get('/health', (req, res) => {
 	res.json({
 		uptime: process.uptime(),
 		connectionCount,
-		address,
+		address: process.env.HIDEIP ? `<redacted>:${port}` : address,
 		name: process.env.NAME,
 		supportedVersions
 	});
@@ -122,7 +122,7 @@ io.on('connection', (socket: socketIO.Socket) => {
 
 server.listen(port);
 (async () => {
-	if (!address)
+	if (!address && !process.env.HIDEIP)
 		address = `http://${await publicIp.v4()}:${port}`;
-	logger.info('CrewLink Server started: %s', address);
+	logger.info('CrewLink Server started: %s', address || `<redacted>:${port}`);
 })();


### PR DESCRIPTION
This adds a feature to hide the server ip in logs, and on the web interface. Can be useful to not make as easy to get when using a DNS record. 


It is atleast in my usecase