### PR TITLE
heroku deploy button link fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Optional environment variables:
 
 To get up and running quickly, you can deploy to Heroku using the button below
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/ottomated/CrewLink-server)
 
 This will deploy an instance of the crewlink-server. You can get the URL of your server by using the app name that you gave when you launched the app on heroku and appending `.herokuapp.com`. You can also find the URL of your server by going to "Settings", scrolling down to "Domains", and removing the `https://` and trailing slash from the url. Using this URL, follow step 4 of the [installation instructions](https://github.com/ottomated/CrewLink-server#manual-installation) to connect your client to your server instance.
 


### PR DESCRIPTION
Fixed link for heroku deploy button that earlier pointed to a blank template rather than pointing towards this repo.

You can verify the link by clicking and deploying the app on heroku.