### PR TITLE
Reduce overall docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+**
+**/.*
+
+!offsets
+!src
+!views
+
+!tsconfig.json
+!package.json
+!yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,35 @@
-# ottomated/crewlink-server
-FROM node:14
-
-# Make a directory for the app, give node user permissions
+#################################################
+# Common base image
+#################################################
+FROM node:14-alpine as common
 RUN mkdir /app && chown node:node /app
-
-# Change to the /app directory *and* make it the default execution directory
 WORKDIR /app
-
-# Do all remaining actions as node, and start the image as node
 USER node
 
-# Copy the repo contents from the build context into the image
-COPY ./ /app/
+# Cache node_modules installation as they change
+# less than code over time.
+COPY package.json yarn.lock tsconfig.json ./
+RUN yarn install --production && \
+    rm -rf ~/.cache /tmp/v8-compile-cache-1000
 
-# Install NPM packages
+#################################################
+# Compile stage
+#################################################
+FROM common as build
 RUN yarn install
-
-# Compile project
+COPY src/ src/
 RUN yarn compile
 
-# Tell the Docker engine the default port is 9736
+#################################################
+# Production stage
+#################################################
+FROM common
+COPY views/ views/
+# It's a toss up on which order offsets and src
+# should be. Offsets are gauranteed to change
+# over time, but src has more changes in `git log`.
+COPY offsets/ offsets/
+COPY --from=build /app/dist/ dist
 EXPOSE 9736
-
-# Run the app when the container starts
 CMD ["node", "dist/index.js"]
+

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
  },
  "scripts": {
   "start": "yarn compile && node dist/index.js",
-  "compile": "tsc",
-  "postinstall": "yarn compile"
+  "compile": "tsc"
  },
  "devDependencies": {
   "@types/express": "^4.17.8",


### PR DESCRIPTION
* Remove postinstall so you can install without dev deps
* Implement a multistage Dockerfile that saves `177 MB`
* Move to `node:14-alpine` to save whopping `820 MB`

Closes: #87 and #88