### PR TITLE
Update Heroku installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,17 @@ Optional environment variables:
 
 ## Deploy to Heroku
 
-To get up and running quickly, you can deploy to Heroku using the button below
+To get up and running quickly, you can deploy to Heroku using the button below:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
-This will deploy an instance of the crewlink-server. You can get the URL of your server by using the app name that you gave when you launched the app on heroku and appending `.herokuapp.com`. You can also find the URL of your server by going to "Settings", scrolling down to "Domains", and removing the `https://` and trailing slash from the url. Using this URL, follow step 4 of the [installation instructions](https://github.com/ottomated/CrewLink-server#manual-installation) to connect your client to your server instance.
+This will deploy an instance of the crewlink-server. You can get the URL of your server by using the app name that you gave when you launched the app on Heroku in the following format: 
+
+```https://<your-app-name>.herokuapp.com/``` 
+
+You can also find the URL of your server by going to "Settings", scrolling down to "Domains". 
+
+Using this URL, copy your server's URL into CrewLink settings. Make sure everyone in your lobby is using the same server.
 
 ## Docker Quickstart
 


### PR DESCRIPTION
The current version of CrewLink does not accept URLs if you remove the `https://` from the Heroku URL. The trailing `/` works with or without. Removed reference to manual installation instructions as that talks about server's IP and port, which may be confusing to users as a URL is provided in the previous step.