### PR TITLE
Fix "EACCES: permission denied error and expose HTTPS-port (443) 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,14 @@ RUN mkdir /app && chown node:node /app
 # Change to the /app directory *and* make it the default execution directory
 WORKDIR /app
 
-# Do all remaining actions as node, and start the image as node
-USER node
-
 # Copy the repo contents from the build context into the image
 COPY ./ /app/
+
+# Give ownership to the app folder to user 'node'.
+RUN chown -R node /app
+
+# Do all remaining actions as node, and start the image as node
+USER node
 
 # Install NPM packages
 RUN yarn install
@@ -20,7 +23,7 @@ RUN yarn install
 RUN yarn compile
 
 # Tell the Docker engine the default port is 9736
-EXPOSE 9736
+EXPOSE 9736 443
 
 # Run the app when the container starts
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
**With this pull request, 2 things are fixed.**

1. The HTTPS port (port 443) is now exposed in the Dockerfile. Without this, it's impossible to use HTTPS.

2. There were errors when making a docker build. When it tries to get the yarn packages, the system gives a permission error, because the 'node'-user is not the owner of the /app directory. This is fixed by first copying the files to /app and THEN use chown. Before this fix, the error was:
```
...
Step 6/9 : RUN yarn install
 ---> Running in 2a2affd4cb2b
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
error Could not write file "/app/yarn-error.log": "EACCES: permission denied, open '/app/yarn-error.log'"
error An unexpected error occurred: "EACCES: permission denied, unlink '/app/node_modules/.yarn-integrity'".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
ERROR: Service 'server' failed to build : The command '/bin/sh -c yarn install' returned a non-zero code: 1
```


**2 notes here:**

1. Is there a reason that port 443 is preferred for HTTPS on the CrewLink server?
`const port = parseInt(process.env.PORT || (httpsEnabled ? '443' : '9736'));`
Only 1 port can be enabled (HTTP or HTTPS) and in that case, wouldn't it make more sense to use 9736 for both? Not that is matters, because you can map the ports with docker.

2. I almost can't believe the second error was not mentioned by anyone here. This is something that everybody who builds a docker image would see. So maybe I am wrong with something here?

Anyway, thank you for the amazing app :).