### PR TITLE
Make ADDRESS option optional, determined automatically if not provided.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ This is the relay server for CrewLink, an Among Us proximity voice chat program.
 Optional environment variables:
 
  - `PORT`: Specifies the port that the server runs on. Defaults to `443` if `HTTPS` is enabled, and `9736` if not.
- - `ADDRESS` **(REQUIRED)**: Specifies the server domain
- - `NAME`: Specifies the server name
+ - `ADDRESS` : Specifies the server domain. If not provided, `ADDRESS` is determined automatically (and possibly incorrectly) from HTTP Request headers.
+ - `NAME`: Specifies the server name.
  - `HTTPS`: Enables https. You must place `privkey.pem` and `fullchain.pem` in your CWD.
  - `SSLPATH`: Specifies an alternate path to SSL certificates.
 


### PR DESCRIPTION
The ADDRESS env variable is used for advertising the address of the service
only. If it is not provided, it can be determined automatically using the
HTTP Request headers 'Host' and 'X-Forwarded-*'. This approach uses ExpressJS
provided functionality but requires 'trusting' headers forwarded from proxies.

Deployers can control the trusted proxies using the TRUST_PROXY option,
documented in the code only as it's very edge-case.

This approach supports the best of both worlds; ADDRESS will use a logical
(probably accurate) value by default, but can be overridden in the case of
an unusual proxy scenario, or a canonical URL is preferred, or as mentioned by
@nathanparekh when no forwarding proxy is involved such as using Docker
port forwarding only.

Closes #116, #117, and #130
Affects #118 (documentation updates will need some rewording)